### PR TITLE
Tidy and increase scope coverage

### DIFF
--- a/JQ.sublime-syntax
+++ b/JQ.sublime-syntax
@@ -79,45 +79,29 @@ contexts:
         - include: strings
         - match: ':'
           scope: punctuation.separator.mapping.key-value.jq
-          set:
-            - meta_scope: meta.block.in_brace.value.jq
-            - include: prototype
-            - include: literals
-            - include: keywords
-            - match: '(?=\})'
-              pop: true
-            - match: ','
-              scope: punctuation.separator.sequence.jq
-              pop: true
+          set: in_brace_value
     - match: '({{identifier}})\s*(:)'
       captures:
         1: entity.name.other.key.jq
         2: punctuation.separator.mapping.key-value.jq
-      push:
-        - meta_content_scope: meta.block.in_brace.value.jq
-        - include: prototype
-        - include: literals
-        - include: keywords
-        - match: '(?=\})'
-          pop: true
-        - match: ','
-          scope: punctuation.separator.sequence.jq
-          pop: true
+      push: in_brace_value
     - include: strings
     - match: ':'
       scope: punctuation.separator.mapping.key-value.jq
-      push:
-        - meta_content_scope: meta.block.in_brace.value.jq
-        - include: prototype
-        - include: literals
-        - include: keywords
-        - match: '(?=\})'
-          pop: true
-        - match: ','
-          scope: punctuation.separator.sequence.jq
-          pop: true
+      push: in_brace_value
     - match: '{{identifier}}'
       scope: entity.name.other.key.jq
+
+  in_brace_value:
+    - meta_content_scope: meta.block.in_brace.value.jq
+    - include: prototype
+    - include: literals
+    - include: keywords
+    - match: '(?=\})'
+      pop: true
+    - match: ','
+      scope: punctuation.separator.sequence.jq
+      pop: true
 
   definitions:
     - match: '(?=\bdef\b\s*{{identifier}})'

--- a/JQ.sublime-syntax
+++ b/JQ.sublime-syntax
@@ -198,11 +198,6 @@ contexts:
       scope: constant.language.null.jq
     - match: \b(true|false)\b
       scope: constant.language.boolean.jq
-    - match: \b(0[xX])(\h+)\b
-      captures:
-        0: meta.number.integer.hexadecimal.jq
-        1: constant.numeric.base.jq
-        2: constant.numeric.value.jq
     - match: '\b(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?\b'
       scope: meta.number.jq constant.numeric.jq
 

--- a/JQ.sublime-syntax
+++ b/JQ.sublime-syntax
@@ -24,14 +24,18 @@ contexts:
   ## Blocks
   enter:
     - match: '\('
+      scope: punctuation.section.parens.begin.jq
       push: in_para
     - match: '\['
+      scope: punctuation.section.brackets.begin.jq
       push: in_bracket
     - match: '\{'
+      scope: punctuation.section.braces.begin.jq
       push: in_brace
 
   exit_para:
     - match: '\)'
+      scope: punctuation.section.parens.end.jq
       pop: true
     - match: '(\}|\])'
       captures:
@@ -40,6 +44,7 @@ contexts:
 
   exit_bracket:
     - match: '\]'
+      scope: punctuation.section.brackets.end.jq
       pop: true
     - match: '(\}|\))'
       captures:
@@ -48,6 +53,7 @@ contexts:
 
   exit_brace:
     - match: '\}'
+      scope: punctuation.section.braces.end.jq
       pop: true
     - match: '(\)|\])'
       captures:
@@ -131,7 +137,9 @@ contexts:
         1: meta.function.parameters.end.jq
         2: punctuation.separator.function_def.jq
       pop: true
-    - match: '\s*;\s*'
+    - match: '\s*(;)\s*'
+      captures:
+        1: punctuation.separator.sequence.jq
     - match: '\$?{{identifier}}'
       scope: variable.parameter.jq
     - match: '(\S)'
@@ -144,6 +152,7 @@ contexts:
     - match: \b(include|import)\b
       scope: keyword.control.import.jq
     - match: ';'
+      scope: punctuation.terminator.jq
       pop: true
 
   keywords:
@@ -154,21 +163,46 @@ contexts:
       scope: constant.language.format.jq
     - match: \b(if|then|else|elif|end)\b
       scope: keyword.control.conditional.jq
-    - match: \b(as|foreach|reduce|and|or|while|until)\b
+    - match: \b(as)\b
+      scope: keyword.context.resource.jq
+      push: variable-definition
+    - match: \b(foreach|reduce|while|until)\b
       scope: keyword.control.flow.jq
-    - match: \b(and|or)\b
-      scope: keyword.operator.logical.jq
+    - include: operators
     - match: '\b(acos|acosh|add|all|any|arrays|ascii_downcase|ascii_upcase|asin|asinh|atan|atan2|atanh|booleans|bsearch|builtins|capture|cbrt|ceil|combinations|contains|copysign|cos|cosh|debug|del|delpaths|drem|empty|endswith|env|erf|erfc|error|exp|exp10|exp2|explode|expm1|fabs|fdim|finites|first|flatten|floor|fma|fmax|fmin|fmod|format|frexp|from_entries|fromdate|fromdateiso8601|fromjson|fromstream|gamma|get_jq_origin|get_prog_origin|get_search_list|getpath|gmtime|group_by|gsub|halt|halt_error|has|hypot|implode|in|index|indices|infinite|input|input_filename|input_line_number|inputs|inside|isempty|isfinite|isinfinite|isnan|isnormal|iterables|j0|j1|jn|join|keys|keys_unsorted|last|ldexp|leaf_paths|length|lgamma|lgamma_r|limit|localtime|log|log10|log1p|log2|logb|ltrimstr|map|map_values|match|max|max_by|min|min_by|mktime|modf|modulemeta|nan|nearbyint|nextafter|nexttoward|normals|not|now|nth|nulls|numbers|objects|path|paths|pow|pow10|range|recurse|recurse_down|remainder|repeat|reverse|rindex|rint|round|rtrimstr|scalars|scalars_or_empty|scalb|scalbln|scan|select|setpath|significand|sin|sinh|sort|sort_by|split|splits|sqrt|startswith|stderr|strflocaltime|strftime|strings|strptime|sub|tan|tanh|test|tgamma|to_entries|todate|todateiso8601|tojson|tonumber|tostream|tostring|transpose|trunc|truncate_stream|type|unique|unique_by|utf8bytelength|values|walk|with_entries|y0|y1|yn)\b'
       scope: support.function.builtin.jq
     - match: '\${{identifier}}'
       scope: variable.language.jq
 
+  operators:
+    - match: \b(and|or)\b
+      scope: keyword.operator.logical.jq
+    - match: \|
+      scope: keyword.operator.jq
+    - match: \.
+      scope: punctuation.accessor.dot.jq
+    - match: =(?!=)
+      scope: keyword.operator.assignment.jq
+    - match: '[><=]=?'
+      scope: keyword.operator.comparison.jq
+    - match: '[-+*/]'
+      scope: keyword.operator.arithmetic.jq
+    - match: ;
+      scope: punctuation.terminator.jq
+
   literals:
     - include: strings
-    - match: \b(true|false|null)\b
-      scope: constant.language.jq
-    - match: '\b((0(x|X)\h*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)\b'
-      scope: constant.numeric.jq
+    - match: \bnull\b
+      scope: constant.language.null.jq
+    - match: \b(true|false)\b
+      scope: constant.language.boolean.jq
+    - match: \b(0[xX])(\h+)\b
+      captures:
+        0: meta.number.integer.hexadecimal.jq
+        1: constant.numeric.base.jq
+        2: constant.numeric.value.jq
+    - match: '\b(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?\b'
+      scope: meta.number.jq constant.numeric.jq
 
   strings:
     # Strings begin and end with quotes, and use backslashes as an escape
@@ -215,4 +249,13 @@ contexts:
   inside_line_comment:
     - meta_scope: comment.line.jq
     - match: $\n?
+      pop: true
+
+  variable-definition:
+    - match: (\$){{identifier}}
+      captures:
+        0: variable.other.constant.jq
+        1: punctuation.definition.variable.jq
+      pop: true
+    - match: (?=\S)
       pop: true

--- a/JQ.sublime-syntax
+++ b/JQ.sublime-syntax
@@ -55,37 +55,33 @@ contexts:
       pop: true
 
   in_para:
-    # For some reason prototype doesnt seem to always work ?
-    - include: comments
-    - include: enter
+    - meta_scope: meta.block.in_para.jq
+    - include: prototype
     - include: exit_para
     - include: literals
     - include: keywords
     - include: definitions
-    - meta_scope: meta.block.in_para.jq
 
   in_bracket:
-    - include: comments
-    - include: enter
+    - meta_scope: meta.block.in_bracket.jq
+    - include: prototype
     - include: exit_bracket
     - include: literals
     - include: keywords
-    - meta_scope: meta.block.in_bracket.jq
 
   in_brace:
-    - include: comments
-    - include: enter
-    - include: exit_brace
     - meta_scope: meta.block.in_brace.jq
+    - include: prototype
+    - include: exit_brace
     - match: '(?="{{identifier}}"\s*:)'
       push:
+        - include: prototype
         - include: strings
         - match: ':'
           scope: punctuation.separator.mapping.key-value.jq
           set:
             - meta_scope: meta.block.in_brace.value.jq
-            - include: comments
-            - include: enter
+            - include: prototype
             - include: literals
             - include: keywords
             - match: '(?=\})'
@@ -99,8 +95,7 @@ contexts:
         2: punctuation.separator.mapping.key-value.jq
       push:
         - meta_content_scope: meta.block.in_brace.value.jq
-        - include: comments
-        - include: enter
+        - include: prototype
         - include: literals
         - include: keywords
         - match: '(?=\})'
@@ -113,8 +108,7 @@ contexts:
       scope: punctuation.separator.mapping.key-value.jq
       push:
         - meta_content_scope: meta.block.in_brace.value.jq
-        - include: comments
-        - include: enter
+        - include: prototype
         - include: literals
         - include: keywords
         - match: '(?=\})'

--- a/JQ.sublime-syntax
+++ b/JQ.sublime-syntax
@@ -171,8 +171,10 @@ contexts:
     - include: operators
     - match: '\b(acos|acosh|add|all|any|arrays|ascii_downcase|ascii_upcase|asin|asinh|atan|atan2|atanh|booleans|bsearch|builtins|capture|cbrt|ceil|combinations|contains|copysign|cos|cosh|debug|del|delpaths|drem|empty|endswith|env|erf|erfc|error|exp|exp10|exp2|explode|expm1|fabs|fdim|finites|first|flatten|floor|fma|fmax|fmin|fmod|format|frexp|from_entries|fromdate|fromdateiso8601|fromjson|fromstream|gamma|get_jq_origin|get_prog_origin|get_search_list|getpath|gmtime|group_by|gsub|halt|halt_error|has|hypot|implode|in|index|indices|infinite|input|input_filename|input_line_number|inputs|inside|isempty|isfinite|isinfinite|isnan|isnormal|iterables|j0|j1|jn|join|keys|keys_unsorted|last|ldexp|leaf_paths|length|lgamma|lgamma_r|limit|localtime|log|log10|log1p|log2|logb|ltrimstr|map|map_values|match|max|max_by|min|min_by|mktime|modf|modulemeta|nan|nearbyint|nextafter|nexttoward|normals|not|now|nth|nulls|numbers|objects|path|paths|pow|pow10|range|recurse|recurse_down|remainder|repeat|reverse|rindex|rint|round|rtrimstr|scalars|scalars_or_empty|scalb|scalbln|scan|select|setpath|significand|sin|sinh|sort|sort_by|split|splits|sqrt|startswith|stderr|strflocaltime|strftime|strings|strptime|sub|tan|tanh|test|tgamma|to_entries|todate|todateiso8601|tojson|tonumber|tostream|tostring|transpose|trunc|truncate_stream|type|unique|unique_by|utf8bytelength|values|walk|with_entries|y0|y1|yn)\b'
       scope: support.function.builtin.jq
-    - match: '\${{identifier}}'
-      scope: variable.language.jq
+    - match: (\$){{identifier}}
+      captures:
+        0: variable.other.readwrite.jq
+        1: punctuation.definition.variable.jq
 
   operators:
     - match: \b(and|or)\b

--- a/JQ.sublime-syntax
+++ b/JQ.sublime-syntax
@@ -74,12 +74,7 @@ contexts:
     - include: prototype
     - include: exit_brace
     - match: '(?="{{identifier}}"\s*:)'
-      push:
-        - include: prototype
-        - include: strings
-        - match: ':'
-          scope: punctuation.separator.mapping.key-value.jq
-          set: in_brace_value
+      push: in_brace_quoted_identifier_mapping
     - match: '({{identifier}})\s*(:)'
       captures:
         1: entity.name.other.key.jq
@@ -91,6 +86,13 @@ contexts:
       push: in_brace_value
     - match: '{{identifier}}'
       scope: entity.name.other.key.jq
+
+  in_brace_quoted_identifier_mapping:
+    - include: prototype
+    - include: strings
+    - match: ':'
+      scope: punctuation.separator.mapping.key-value.jq
+      set: in_brace_value
 
   in_brace_value:
     - meta_content_scope: meta.block.in_brace.value.jq
@@ -105,38 +107,44 @@ contexts:
 
   definitions:
     - match: '(?=\bdef\b\s*{{identifier}})'
-      push:
-        - meta_content_scope: meta.function.jq
-        - match: \bdef\b
-          scope: keyword.other.function_def.jq
-        - match: '{{identifier}}'
-          scope: entity.name.function.jq
-        - match: '(?=[:[^\s\(]])'
-          pop: true
-        - match: '\(\s*'
-          scope: meta.function.parameters.begin.jq
-          set:
-            - meta_content_scope: meta.function.parameters.list.jq
-            - match: '\s*(\))\s*(:)'
-              captures:
-                1: meta.function.parameters.end.jq
-                2: punctuation.separator.function_def.jq
-              pop: true
-            - match: '\s*;\s*'
-            - match: '\$?{{identifier}}'
-              scope: variable.parameter.jq
-            - match: '(\S)'
-              scope: invalid.illegal.jq
-              pop: true
+      push: func_def
 
     - match: '(?=\b(include|import)\b\s*\"[^\";]+\"\s*;)'
-      push:
-        - meta_content_scope: meta.import.statement.jq
-        - include: strings
-        - match: \b(include|import)\b
-          scope: keyword.control.import.jq
-        - match: ';'
-          pop: true
+      push: include_import
+
+  func_def:
+    - meta_content_scope: meta.function.jq
+    - match: \bdef\b
+      scope: keyword.other.function_def.jq
+    - match: '{{identifier}}'
+      scope: entity.name.function.jq
+    - match: '(?=[:[^\s\(]])'
+      pop: true
+    - match: '\(\s*'
+      scope: meta.function.parameters.begin.jq
+      set: func_def_args
+
+  func_def_args:
+    - meta_content_scope: meta.function.parameters.list.jq
+    - match: '\s*(\))\s*(:)'
+      captures:
+        1: meta.function.parameters.end.jq
+        2: punctuation.separator.function_def.jq
+      pop: true
+    - match: '\s*;\s*'
+    - match: '\$?{{identifier}}'
+      scope: variable.parameter.jq
+    - match: '(\S)'
+      scope: invalid.illegal.jq
+      pop: true
+
+  include_import:
+    - meta_content_scope: meta.import.statement.jq
+    - include: strings
+    - match: \b(include|import)\b
+      scope: keyword.control.import.jq
+    - match: ';'
+      pop: true
 
   keywords:
     # TODO better imports
@@ -202,7 +210,9 @@ contexts:
   comments:
     - match: '#'
       scope: punctuation.definition.comment.jq
-      push:
-        - meta_scope: comment.line.jq
-        - match: $\n?
-          pop: true
+      push: inside_line_comment
+
+  inside_line_comment:
+    - meta_scope: comment.line.jq
+    - match: $\n?
+      pop: true

--- a/syntax_test_jq.jq
+++ b/syntax_test_jq.jq
@@ -110,6 +110,8 @@ $some_var
 #                  ^ punctuation.definition.variable.jq
   {};
   .[$abc] = (
+#   ^^^^ variable.other.readwrite.jq
+#   ^ punctuation.definition.variable.jq
     $some_var[$abc][]
     | select (.foo and .bar)
 #                  ^^^ keyword.operator.logical.jq

--- a/syntax_test_jq.jq
+++ b/syntax_test_jq.jq
@@ -94,11 +94,6 @@ true false null
 #    ^^^^^ constant.language.boolean.jq
 #          ^^^^ constant.language.null.jq
 
-  0x123
-# ^^^^^ meta.number.integer.hexadecimal.jq
-# ^^ constant.numeric.base.jq
-#   ^^^ constant.numeric.value.jq
-
 $some_var
 | reduce keys[] as $abc (
 # ^^^^^^ keyword.control.flow.jq

--- a/syntax_test_jq.jq
+++ b/syntax_test_jq.jq
@@ -21,6 +21,13 @@ import "test"; # with a comment
     (keys | .[3]): "haha",
 #    ^^^^ support.function.builtin.jq
 #   ^^^^^^^^^^^^^ - meta.block.in_brace.value.jq
+#   ^ punctuation.section.parens.begin.jq
+#         ^ keyword.operator.jq
+#           ^ punctuation.accessor.dot.jq
+#            ^ punctuation.section.brackets.begin.jq
+#             ^ constant.numeric.jq
+#              ^ punctuation.section.brackets.end.jq
+#               ^ punctuation.section.parens.end.jq
 #                ^ punctuation.separator.mapping.key-value.jq
 #                  ^^^^^^ meta.block.in_brace.value.jq string.quoted.double
 #                        ^ punctuation.separator.sequence.jq
@@ -56,6 +63,7 @@ def keys($value; $value; test):
 
     12
 ;
+# <- punctuation.terminator.jq
 
 { array: [1, 2, 3 ,4] } | @json "My string with eval: \( .array | ( . | . += 1 ) )"
 # <- meta.block.in_brace.jq -  meta.block.in_brace.jq meta.block.in_brace.jq
@@ -72,6 +80,42 @@ def keys($value; $value; test):
 
 {i:0} | while(.i < 10 ; .i += 1)
 #       ^^^^^ keyword.control.flow.jq
+#                ^ keyword.operator.comparison.jq
+#                     ^ punctuation.terminator.jq
+#                          ^ keyword.operator.arithmetic.jq
+#                           ^ keyword.operator.assignment.jq
 
 {i:0} | until(.i == 10 ; .i += 1)
 #       ^^^^^ keyword.control.flow.jq
+#                ^^ keyword.operator.comparison.jq
+
+true false null
+# ^^ constant.language.boolean.jq
+#    ^^^^^ constant.language.boolean.jq
+#          ^^^^ constant.language.null.jq
+
+  0x123
+# ^^^^^ meta.number.integer.hexadecimal.jq
+# ^^ constant.numeric.base.jq
+#   ^^^ constant.numeric.value.jq
+
+$some_var
+| reduce keys[] as $abc (
+# ^^^^^^ keyword.control.flow.jq
+#        ^^^^ support.function.builtin.jq
+#            ^ punctuation.section.brackets.begin.jq
+#             ^ punctuation.section.brackets.end.jq
+#               ^^ keyword.context.resource.jq
+#                  ^^^^ variable.other.constant.jq
+#                  ^ punctuation.definition.variable.jq
+  {};
+  .[$abc] = (
+    $some_var[$abc][]
+    | select (.foo and .bar)
+#                  ^^^ keyword.operator.logical.jq
+  )
+)
+
+{($abc): ."\($abc)"}
+
+with_entries( {key: .key, value: (.value | map(select(.bar == true ))) } )


### PR DESCRIPTION
Hi,

This PR tidies the syntax to follow some of the latest recommendations followed by the syntax definitions which ship with ST. Namely, they are to use named contexts in place of anonymous ones (which is useful in case the syntax ever needs to be extended in future) and to better adhere to the [official scope naming guidelines](https://www.sublimetext.com/docs/scope_naming.html).

I also added scopes for tokens (like operators and brackets) which were missing.