### PR TITLE
Match against shebang

### DIFF
--- a/JQ.sublime-syntax
+++ b/JQ.sublime-syntax
@@ -5,6 +5,11 @@ file_extensions:
   - jq
 scope: source.jq
 
+first_line_match: |-
+  (?xi:
+    ^ \#! .* \b(jq|gojq|jaq|yq)\b  # shebang
+  )
+
 variables:
   identifier_start: '[[:alpha:]_]'
   identifier: '\b{{identifier_start}}[[:alnum:]_]*\b'


### PR DESCRIPTION
Add the `first_line_match` header field to match against jq (+popular implementations of) in the shebang line, for scripts that don't have the `.jq` extension